### PR TITLE
Change public default to empty string

### DIFF
--- a/config.defaults.yml
+++ b/config.defaults.yml
@@ -2,7 +2,7 @@ key_size: 4096
 # We need an ACME server to talk to, see github.com/letsencrypt/boulder
 endpoint: 'https://acme-v01.api.letsencrypt.org/'
 domains: []
-public: []
+public: ''
 output_dir: '~/le_certs/'
 letsencrypt_account_email: ''
 api_url: 'https://api.webfaction.com/'


### PR DESCRIPTION
Current default is array, but array is invalid for this option.