### PR TITLE
Allow certificates to be renewed within 30 days of expiration, up from 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 
+* [#147](https://github.com/will-in-wi/letsencrypt-webfaction/pull/147) - Changed `RENEWAL_DELTA` to 30 days per LetsEncrypt's recommendation. (@shannonturner)
 * Your change here!
 
 v3.1.1

--- a/lib/letsencrypt_webfaction/application/run.rb
+++ b/lib/letsencrypt_webfaction/application/run.rb
@@ -11,7 +11,7 @@ require 'pathname'
 module LetsencryptWebfaction
   module Application
     class Run
-      RENEWAL_DELTA = 14 # days
+      RENEWAL_DELTA = 30 # days
 
       def initialize(args)
         @config_path = DefaultConfigPath.new

--- a/spec/lib/letsencrypt_webfaction/application/run_spec.rb
+++ b/spec/lib/letsencrypt_webfaction/application/run_spec.rb
@@ -257,12 +257,12 @@ module LetsencryptWebfaction
         end
 
         context 'with still valid cert' do
-          let(:expiration) { '2017-01-30' }
+          let(:expiration) { '2017-02-28' }
           let(:domains) { ['test.example.com', 'test1.example.com'] }
 
           it 'skips cert' do
             Timecop.freeze(Date.new(2017, 1, 1)) do
-              expect { application.run! }.to output(/29 days until expiration of myname\. Skipping\.\.\./).to_stdout
+              expect { application.run! }.to output(/58 days until expiration of myname\. Skipping\.\.\./).to_stdout
             end
           end
         end


### PR DESCRIPTION
Changed RENEWAL_DELTA to 30 days per LetsEncrypt's recommendation:

> We recommend renewing certificates automatically when they have a third of their
> total lifetime left. For Let's Encrypt's current 90-day certificates, that means
> renewing 30 days before expiration.

This will allow certificates to be renewed if they have fewer than 30 days until expiration, up from 14 days until expiration.