### PR TITLE
New --force argument for reissuing all certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 
+* New `--force` argument for easier handling of `endpoint` switching. Fixes [#132](https://github.com/will-in-wi/letsencrypt-webfaction/issues/132)
 * Your change here!
 
 v3.1.2

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The commands are `init` and `run`. You can add the `--quiet` argument to the `ru
 
 To test certificate issuance, consider using the [LetsEncrypt staging server](https://community.letsencrypt.org/t/testing-against-the-lets-encrypt-staging-environment/6763). This doesn't have the rate limit of 5 certs per domain every 7 days. You can change the `endpoint` config line to be `https://acme-staging.api.letsencrypt.org/` in order to test the system.
 
+After switching endpoints, you will likely want to run the command with `--force` in order to reissue all certificates from the new endpoint.
+
 ### Operation
 
 When letsencrypt_webfaction runs, it places verification files into the public directory specified, validates the domains with LetsEncrypt, and then uploads the certificate to WebFaction's API.

--- a/spec/lib/letsencrypt_webfaction/application/run_spec.rb
+++ b/spec/lib/letsencrypt_webfaction/application/run_spec.rb
@@ -267,6 +267,24 @@ module LetsencryptWebfaction
           end
         end
 
+        context 'with force-issued cert' do
+          let(:args) { ['--force'] }
+          let(:expiration) { '2017-02-28' }
+          let(:domains) { ['test.example.com', 'test1.example.com'] }
+
+          before :each do
+            stub_request(:post, 'https://wfserverapi.example.com/')
+              .with(body: "<?xml version=\"1.0\" ?><methodCall><methodName>update_certificate</methodName><params><param><value><string>oz7e1xz9r0mf0wgue22hsj8tgkhqyo74</string></value></param><param><value><string>myname</string></value></param><param><value><string>CERTIFICATE</string></value></param><param><value><string>PRIVATE KEY</string></value></param><param><value><string>CHAIN!</string></value></param></params></methodCall>\n")
+              .to_return(status: 200, body: fixture('create_certificate_response.xml'), headers: {})
+          end
+
+          it 'issues cert' do
+            Timecop.freeze(Date.new(2017, 1, 1)) do
+              expect { application.run! }.to output(/Force issuing myname\./).to_stdout
+            end
+          end
+        end
+
         context 'with expires shortly cert' do
           let(:expiration) { '2017-01-30' }
           let(:domains) { ['test.example.com', 'test1.example.com'] }

--- a/templates/letsencrypt_webfaction.toml
+++ b/templates/letsencrypt_webfaction.toml
@@ -6,7 +6,8 @@ password = "mypassword"
 letsencrypt_account_email = "me@example.com"
 
 # The ACME endpoint. Use the staging server until you get everything working.
-# Then switch to the production endpoint.
+# Then switch to the production endpoint. You may want to run with the --force
+# command after switching to reissue all certificates.
 endpoint = "https://acme-staging.api.letsencrypt.org/" # Staging
 #endpoint = "https://acme-v01.api.letsencrypt.org/" # Production
 


### PR DESCRIPTION
Per frequent request in https://github.com/will-in-wi/letsencrypt-webfaction/issues/132.

When `--force` is passed, all of the certificates are reissued, regardless of expiration. Useful when you've set up a new configuration against staging and need to switch to the production certificates.